### PR TITLE
Switch rdo_dashboards to use smashing command

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,13 @@
     home: /srv/{{ dashboards_user }}
     git_checkout: /srv/{{ dashboards_user }}/git
 
+# CRB is needed for some of the required packages
+- name: Enable CRB repo CentOS 9
+  become: true
+  ansible.builtin.command: dnf config-manager --enable crb --save
+  changed_when: false
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "9"
+
 - name: Install needed packages
   package:
     name:
@@ -61,7 +68,9 @@
       # no manual changes allowed, crush them all
       force: yes
 
-  - command: "bundle install --path ~/.gem"
+  - shell: |
+      bundle config set --local path ~/.gem
+      bundle install
     args:
       chdir: '{{ git_checkout }}'
 

--- a/templates/rdo_dashboards.service
+++ b/templates/rdo_dashboards.service
@@ -7,7 +7,7 @@ Environment=PATH={{ home }}/bin:/usr/bin:/usr/local/bin
 User={{ dashboards_user }}
 Type=simple
 WorkingDirectory={{ git_checkout }}
-ExecStart=/usr/bin/bundle exec dashing start
+ExecStart=/usr/bin/bundle exec smashing start
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In order to support CentOS Stream 9, rdo_dashboard is switching to use smashing which is the "spiritual successor to dashing" [1]

Also, this patch enables crb repo which is needed to install some packages required for the dashboard.

[1] https://github.com/Smashing/smashing
[2] https://review.rdoproject.org/r/c/rdo-infra/rdo-dashboards/+/52572